### PR TITLE
Add scope & link params on checkout & context commands.

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -23,11 +23,8 @@ fn main() {
         // Create config dir if not exists.
         fs::create_dir(config_dir).ok();
 
-        copy_or_replace(
-            &project_root.join(".git-kit.yml"),
-            &config_dir.join(".git-kit.yml"),
-        )
-        .expect("Failed to copy or update to the latest config file for git-kit");
+        copy_or_replace(&project_root.join("templates"), &config_dir.to_path_buf())
+            .expect("Failed to copy or update to the latest config file for git-kit");
 
         let mut connection =
             Connection::open(config_dir.join("db")).expect("Failed to open sqlite connection");
@@ -35,8 +32,10 @@ fn main() {
         db_migrations(
             &mut connection,
             MigrationContext {
-                config_path: config_dir.join(".git-kit.yml"),
-                enable_side_effects: true,
+                default_configs: Some(migrations::DefaultConfig {
+                    default: config_dir.join("default.yml"),
+                    conventional: config_dir.join("conventional.yml"),
+                }),
                 version: Some(4),
             },
         )

--- a/build.rs
+++ b/build.rs
@@ -37,7 +37,7 @@ fn main() {
             MigrationContext {
                 config_path: config_dir.join(".git-kit.yml"),
                 enable_side_effects: true,
-                version: Some(2),
+                version: Some(4),
             },
         )
         .expect("Failed to apply migrations.");

--- a/src/adapters/sqlite.rs
+++ b/src/adapters/sqlite.rs
@@ -39,12 +39,14 @@ impl domain::adapters::Store for Sqlite {
 
         self.connection
             .execute(
-                "REPLACE INTO branch (name, ticket, data, created) VALUES (?1, ?2, ?3, ?4)",
+                "REPLACE INTO branch (name, ticket, data, created, link, scope) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
                 (
                     &branch.name,
                     &branch.ticket,
                     &branch.data,
                     &branch.created.to_rfc3339(),
+                    &branch.link,
+                    &branch.scope
                 ),
             )
             .with_context(|| format!("Failed to update branch '{}'", &branch.name))?;
@@ -62,7 +64,7 @@ impl domain::adapters::Store for Sqlite {
         );
 
         let branch = self.connection.query_row(
-            "SELECT name, ticket, data, created FROM branch where name = ?",
+            "SELECT name, ticket, data, created, link, scope FROM branch where name = ?",
             [name],
             |row| Branch::try_from(row),
         )?;
@@ -219,6 +221,8 @@ impl<'a> TryFrom<&Row<'a>> for Branch {
             ticket: value.get(1)?,
             data: value.get(2)?,
             created,
+            link: value.get(4)?,
+            scope: value.get(5)?,
         };
 
         Ok(branch)
@@ -254,12 +258,14 @@ mod tests {
         // Assert
         assert_eq!(branch_count(&store.connection)?, 1);
 
-        let (name, ticket, data, created) = select_branch_row(&store.connection)?;
+        let (name, ticket, data, created, link, scope) = select_branch_row(&store.connection)?;
 
         assert_eq!(branch.name, name);
         assert_eq!(branch.ticket, ticket);
         assert_eq!(branch.data, data);
         assert_eq!(branch.created.to_rfc3339(), created);
+        assert_eq!(branch.link, link);
+        assert_eq!(branch.scope, scope);
 
         Ok(())
     }
@@ -272,12 +278,14 @@ mod tests {
         let store = Sqlite { connection };
 
         store.connection.execute(
-            "INSERT INTO branch (name, ticket, data, created) VALUES (?1, ?2, ?3, ?4)",
+            "INSERT INTO branch (name, ticket, data, created, link, scope) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
             (
                 &branch.name,
                 &branch.ticket,
                 &branch.data,
                 &branch.created.to_rfc3339(),
+                &branch.link,
+                &branch.scope
             ),
         )?;
 
@@ -292,12 +300,14 @@ mod tests {
         // Assert
         assert_eq!(branch_count(&store.connection)?, 1);
 
-        let (name, ticket, data, created) = select_branch_row(&store.connection)?;
+        let (name, ticket, data, created, link, scope) = select_branch_row(&store.connection)?;
 
         assert_eq!(updated_branch.name, name);
         assert_eq!(updated_branch.ticket, ticket);
         assert_eq!(updated_branch.data, data);
         assert_eq!(updated_branch.created.to_rfc3339(), created);
+        assert_eq!(updated_branch.link, link);
+        assert_eq!(updated_branch.scope, scope);
 
         Ok(())
     }
@@ -318,14 +328,16 @@ mod tests {
             branches.insert(name, branch.clone());
 
             store.connection.execute(
-                "INSERT INTO branch (name, ticket, data, created) VALUES (?1, ?2, ?3, ?4)",
+                "INSERT INTO branch (name, ticket, data, created, link, scope) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
                 (
                     &branch.name,
                     &branch.ticket,
                     &branch.data,
                     &branch.created.to_rfc3339(),
+                    &branch.link,
+                    &branch.scope
                 ),
-            )?;
+            ).unwrap();
         }
 
         let context = AppContext {
@@ -375,12 +387,14 @@ mod tests {
         let expected = fake_branch(Some(name.clone()), Some(repo.clone()))?;
 
         context.store.connection.execute(
-            "INSERT INTO branch (name, ticket, data, created) VALUES (?1, ?2, ?3, ?4)",
+            "INSERT INTO branch (name, ticket, data, created, link, scope) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
             (
                 &expected.name,
                 &expected.ticket,
                 &expected.data,
                 &expected.created.to_rfc3339(),
+                &expected.link,
+                &expected.scope
             ),
         )?;
 
@@ -617,24 +631,39 @@ mod tests {
     fn fake_branch(name: Option<String>, repo: Option<String>) -> anyhow::Result<Branch> {
         let name = name.unwrap_or(Faker.fake());
         let repo = repo.unwrap_or(Faker.fake());
-        let ticket: Option<String> = Faker.fake();
 
-        Ok(Branch::new(&name, &repo, ticket)?)
+        Ok(Branch::new(
+            &name,
+            &repo,
+            Faker.fake(),
+            Faker.fake(),
+            Faker.fake(),
+        )?)
     }
 
     fn select_branch_row(
         conn: &Connection,
-    ) -> anyhow::Result<(String, String, Option<Vec<u8>>, String)> {
-        let (name, ticket, data, created) = conn.query_row("SELECT * FROM branch", [], |row| {
-            Ok((
-                row.get::<_, String>(0)?,
-                row.get::<_, String>(1)?,
-                row.get::<_, Option<Vec<u8>>>(2)?,
-                row.get::<_, String>(3)?,
-            ))
-        })?;
+    ) -> anyhow::Result<(
+        String,
+        String,
+        Option<Vec<u8>>,
+        String,
+        Option<String>,
+        Option<String>,
+    )> {
+        let (name, ticket, data, created, link, scope) =
+            conn.query_row("SELECT * FROM branch", [], |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, Option<Vec<u8>>>(2)?,
+                    row.get::<_, String>(3)?,
+                    row.get::<_, Option<String>>(4)?,
+                    row.get::<_, Option<String>>(5)?,
+                ))
+            })?;
 
-        Ok((name, ticket, data, created))
+        Ok((name, ticket, data, created, link, scope))
     }
 
     fn select_config_row(conn: &Connection, key: String) -> anyhow::Result<Config> {

--- a/src/adapters/sqlite.rs
+++ b/src/adapters/sqlite.rs
@@ -177,10 +177,13 @@ impl<'a> TryFrom<&Row<'a>> for Config {
 
     fn try_from(value: &Row) -> Result<Self, Self::Error> {
         let status = value.get::<_, String>(2)?.try_into().map_err(|e| {
-            log::error!("Corrupted data failed to convert to valid path, {}", e);
+            log::error!(
+                "Corrupted data failed to convert to valid config status, {}",
+                e
+            );
             rusqlite::Error::InvalidColumnType(
                 2,
-                "Failed to convert to valid path".into(),
+                "Failed to convert to valid config status".into(),
                 Type::Text,
             )
         })?;
@@ -684,8 +687,7 @@ mod tests {
         db_migrations(
             &mut conn,
             MigrationContext {
-                config_path: Path::new(".").to_owned(),
-                enable_side_effects: false,
+                default_configs: None,
                 version: None,
             },
         )?;

--- a/src/app_config.rs
+++ b/src/app_config.rs
@@ -148,9 +148,12 @@ mod tests {
     }
 
     #[test]
-    fn repo_dir_with_config_file_used_over_user_and_default_has_priority_2() -> anyhow::Result<()> {
+    fn repo_dir_with_config_file_overrides_any_user_or_default_config_has_priority_2(
+    ) -> anyhow::Result<()> {
         let git: &dyn adapters::Git = &Git;
         let repo_root_with_config = git.root_directory()?;
+        let config = repo_root_with_config.join(".git-kit.yml");
+        std::fs::File::create(&config)?;
 
         for key in [ConfigKey::Default, ConfigKey::User(Faker.fake())] {
             let config_dir = AppConfig::get_config_path(
@@ -162,8 +165,11 @@ mod tests {
                 repo_root_with_config.clone(),
             )?;
 
-            assert_eq!(config_dir, repo_root_with_config.join(".git-kit.yml"));
+            assert_eq!(config_dir, config);
         }
+
+        std::fs::remove_file(config)?;
+
         Ok(())
     }
 

--- a/src/cli/checkout/args.rs
+++ b/src/cli/checkout/args.rs
@@ -9,4 +9,12 @@ pub struct Arguments {
     /// Issue ticket number related to the branch.
     #[clap(short, long, value_parser)]
     pub ticket: Option<String>,
+
+    /// Short describing a section of the codebase the changes relate to.
+    #[clap(short, long, value_parser)]
+    pub scope: Option<String>,
+
+    /// Issue ticket number link.
+    #[clap(short, long, value_parser)]
+    pub link: Option<String>,
 }

--- a/src/cli/commit/args.rs
+++ b/src/cli/commit/args.rs
@@ -82,15 +82,9 @@ impl Arguments {
             .map(|branch| (Some(branch.ticket), branch.scope, branch.link))
             .unwrap_or((None, None, None));
 
-        let ticket = merge(
-            self.ticket.clone().none_if_empty(),
-            ticket.none_if_empty(),
-        );
+        let ticket = merge(self.ticket.clone().none_if_empty(), ticket.none_if_empty());
 
-        let scope = merge(
-            self.scope.clone().none_if_empty(),
-            scope.none_if_empty(),
-        );
+        let scope = merge(self.scope.clone().none_if_empty(), scope.none_if_empty());
 
         let contents = Self::replace_or_remove(template, "ticket_num", ticket)?;
         let contents = Self::replace_or_remove(contents, "scope", scope)?;
@@ -487,8 +481,7 @@ mod tests {
         db_migrations(
             &mut conn,
             MigrationContext {
-                config_path: PathBuf::new(),
-                enable_side_effects: false,
+                default_configs: None,
                 version: None,
             },
         )?;

--- a/src/cli/commit/handler.rs
+++ b/src/cli/commit/handler.rs
@@ -4,6 +4,7 @@ use super::Arguments;
 
 pub fn handler(actions: &dyn Actor, config: &AppConfig, args: Arguments) -> anyhow::Result<()> {
     config.validate_template(&args.template)?;
+    // TODO: Could we do a prompt if no ticket / args found ?
     actions.commit(args)?;
 
     Ok(())

--- a/src/cli/context/args.rs
+++ b/src/cli/context/args.rs
@@ -4,5 +4,13 @@ use clap::Args;
 pub struct Arguments {
     /// Issue ticket number related to the current branch.
     #[clap(value_parser)]
-    pub ticket: String,
+    pub ticket: Option<String>,
+
+    /// Short describing a section of the codebase the changes relate to.
+    #[clap(short, long, value_parser)]
+    pub scope: Option<String>,
+
+    /// Issue ticket number link.
+    #[clap(short, long, value_parser)]
+    pub link: Option<String>,
 }

--- a/src/domain/commands/actions.rs
+++ b/src/domain/commands/actions.rs
@@ -26,7 +26,7 @@ impl<'a, C: Git, S: Store> Actor for Actions<'a, C, S> {
         let repo_name = self.context.git.get_repo_name()?;
         let branch_name = self.context.git.get_branch_name()?;
 
-        let branch = Branch::new(&branch_name, &repo_name, Some(args.ticket))?;
+        let branch = Branch::new(&branch_name, &repo_name, args.ticket, args.link, args.scope)?;
         self.context.store.persist_branch(&branch)?;
 
         Ok(branch)
@@ -48,7 +48,7 @@ impl<'a, C: Git, S: Store> Actor for Actions<'a, C, S> {
         // We want to store the branch name against and ticket number
         // So whenever we commit we get the ticket number from the branch
         let repo_name = self.context.git.get_repo_name()?;
-        let branch = Branch::new(&args.name, &repo_name, args.ticket.clone())?;
+        let branch = Branch::new(&args.name, &repo_name, args.ticket, args.link, args.scope)?;
         self.context.store.persist_branch(&branch)?;
 
         Ok(branch)

--- a/src/domain/commands/actions.rs
+++ b/src/domain/commands/actions.rs
@@ -80,7 +80,6 @@ mod tests {
     use crate::app_config::TemplateConfig;
     use crate::app_context::AppContext;
     use crate::domain::adapters::CheckoutStatus;
-    use crate::migrations::DefaultConfig;
     use crate::migrations::{db_migrations, MigrationContext};
 
     use super::*;

--- a/src/domain/commands/actions.rs
+++ b/src/domain/commands/actions.rs
@@ -79,7 +79,6 @@ mod tests {
     use crate::app_config::CommitConfig;
     use crate::app_config::TemplateConfig;
     use crate::app_context::AppContext;
-
     use crate::domain::adapters::CheckoutStatus;
     use crate::migrations::{db_migrations, MigrationContext};
 
@@ -101,7 +100,7 @@ mod tests {
             ..GitCommandMock::fake()
         };
 
-        let context = fake_context(git_commands.clone())?;
+        let context = fake_context(git_commands.clone(), fake_config())?;
         let actions = Actions::new(&context);
 
         // Act
@@ -148,7 +147,7 @@ mod tests {
             ..GitCommandMock::fake()
         };
 
-        let context = fake_context(git_commands.clone())?;
+        let context = fake_context(git_commands.clone(), fake_config())?;
         let actions = Actions::new(&context);
 
         // Act
@@ -191,7 +190,7 @@ mod tests {
             ..GitCommandMock::fake()
         };
 
-        let context = fake_context(git_commands.clone())?;
+        let context = fake_context(git_commands.clone(), fake_config())?;
         let actions = Actions::new(&context);
 
         // Act
@@ -228,7 +227,7 @@ mod tests {
             ..GitCommandMock::fake()
         };
 
-        let context = fake_context(git_commands.clone())?;
+        let context = fake_context(git_commands.clone(), fake_config())?;
         let actions = Actions::new(&context);
 
         // Act
@@ -274,7 +273,7 @@ mod tests {
             ..GitCommandMock::fake()
         };
 
-        let context = fake_context(git_commands.clone())?;
+        let context = fake_context(git_commands.clone(), fake_config())?;
         let actions = Actions::new(&context);
 
         // Act
@@ -303,102 +302,131 @@ mod tests {
     }
 
     #[test]
-    fn commit_message_with_ticket_and_message_arg_are_formatted_correctly() -> anyhow::Result<()> {
+    fn commit_message_with_all_arguments_are_injected_into_the_template_with_nothing_persisted(
+    ) -> anyhow::Result<()> {
+        // Arrange
+        let (template, template_config) = fake_template();
+
+        let config = AppConfig {
+            commit: CommitConfig {
+                templates: HashMap::from([(template.clone(), template_config)]),
+            },
+        };
+
+        let context = fake_context(GitCommandMock::fake(), config)?;
+        let actions = Actions::new(&context);
+
         let args = commit::Arguments {
             ticket: Some(Faker.fake()),
             message: Some(Faker.fake()),
+            scope: Some(Faker.fake()),
+            template,
             ..fake_commit_args()
         };
 
-        for (template_contents, args) in fake_commit_templates(Some(args)) {
-            let context = fake_context(GitCommandMock::fake())?;
-            let actions = Actions::new(&context);
+        // Act
+        let contents = actions
+            .commit(args.clone())
+            .expect("Error performing 'commit' action");
 
-            // Act
-            let contents = actions
-                .commit(args.clone())
-                .expect("Error performing 'commit' action");
+        // Assert
+        let expected = format!(
+            "[{}] message: '{}', scope: '{}', link: '{}'",
+            args.ticket.clone().unwrap(),
+            args.message.clone().unwrap(),
+            args.scope.unwrap(),
+            ""
+        );
+        assert_eq!(expected, contents);
 
-            // Assert
-            let expected = format!(
-                "[{}] {} {}",
-                args.ticket.clone().unwrap_or("".into()),
-                template_contents,
-                args.message.clone().unwrap_or("".into())
-            );
-            assert_eq!(expected, contents);
-
-            context.close()?;
-        }
+        context.close()?;
 
         Ok(())
     }
 
     #[test]
-    fn commit_message_with_no_ticket_or_stored_branch_defaults_correctly() -> anyhow::Result<()> {
-        let args = commit::Arguments {
-            ticket: None,
-            ..fake_commit_args()
+    fn commit_message_with_no_args_or_stored_branch_defaults_correctly() -> anyhow::Result<()> {
+        // Arrange
+        let (template, template_config) = fake_template();
+
+        let config = AppConfig {
+            commit: CommitConfig {
+                templates: HashMap::from([(template.clone(), template_config)]),
+            },
         };
 
-        for (template_contents, args) in fake_commit_templates(Some(args)) {
-            let context = fake_context(GitCommandMock::fake())?;
-            let actions = Actions::new(&context);
+        let context = fake_context(GitCommandMock::fake(), config)?;
+        let actions = Actions::new(&context);
 
-            // Act
-            let contents = actions
-                .commit(args.clone())
-                .expect("Error performing 'commit' action");
+        let args = commit::Arguments {
+            ticket: None,
+            message: None,
+            scope: None,
+            template,
+        };
 
-            // Assert
-            let expected = format!(
-                "{} {}",
-                template_contents,
-                args.message.clone().unwrap_or("".into())
-            );
-            assert_eq!(expected.trim(), contents);
+        // Act
+        let contents = actions
+            .commit(args.clone())
+            .expect("Error performing 'commit' action");
 
-            context.close()?;
-        }
+        // Assert
+        assert_eq!("message: '', scope: '', link: ''", contents);
+
+        context.close()?;
 
         Ok(())
     }
 
     #[test]
-    fn commit_message_with_no_ticket_uses_stored_branch() -> anyhow::Result<()> {
-        let args = commit::Arguments {
-            ticket: None,
-            ..fake_commit_args()
+    fn commit_message_with_no_commit_args_defaults_to_stored_branch_values() -> anyhow::Result<()> {
+        // Arrange
+        let (template, template_config) = fake_template();
+
+        let config = AppConfig {
+            commit: CommitConfig {
+                templates: HashMap::from([(template.clone(), template_config)]),
+            },
         };
 
-        for (template_contents, args) in fake_commit_templates(Some(args)) {
-            let context = fake_context(GitCommandMock::fake())?;
-            let actions = Actions::new(&context);
+        let args = commit::Arguments {
+            template,
+            message: Some(Faker.fake()),
+            ticket: None,
+            scope: None,
+        };
 
-            let branch_name = Some(context.git.get_branch_name()?);
-            let repo_name = Some(context.git.get_repo_name()?);
-            let ticket = None;
-            setup_db(
-                &context.store,
-                Some(&fake_branch(branch_name.clone(), repo_name, ticket)?),
-            )?;
+        let context = fake_context(GitCommandMock::fake(), config)?;
+        let actions = Actions::new(&context);
 
-            // Act
-            let commit_message = actions
-                .commit(args.clone())
-                .expect("Error performing 'commit' action");
+        let branch_name = Some(context.git.get_branch_name()?);
+        let repo_name = Some(context.git.get_repo_name()?);
+        let ticket = None;
+        let branch = Branch {
+            link: Some(Faker.fake()),
+            scope: Some(Faker.fake()),
+            ..fake_branch(branch_name.clone(), repo_name, ticket)?
+        };
 
-            // Assert
-            let expected = format!(
-                "[{}] {} {}",
-                branch_name.unwrap(),
-                template_contents,
-                args.message.clone().unwrap_or("".into())
-            );
-            assert_eq!(expected.trim(), commit_message);
+        setup_db(&context.store, Some(&branch))?;
 
-            context.close()?;
-        }
+        // Act
+        let commit_message = actions
+            .commit(args.clone())
+            .expect("Error performing 'commit' action");
+
+        // Assert
+        let expected = format!(
+            "[{}] message: '{}', scope: '{}', link: '{}'",
+            branch_name.unwrap(),
+            args.message.unwrap(),
+            branch.scope.unwrap(),
+            branch.link.unwrap()
+        );
+
+        assert_eq!(expected.trim(), commit_message);
+
+        context.close()?;
 
         Ok(())
     }
@@ -411,8 +439,12 @@ mod tests {
         }
     }
 
-    fn fake_context<'a, C: Git>(git: C) -> anyhow::Result<AppContext<C, Sqlite>> {
+    fn fake_context<'a, C: Git>(
+        git: C,
+        config: AppConfig,
+    ) -> anyhow::Result<AppContext<C, Sqlite>> {
         let mut connection = Connection::open_in_memory()?;
+
         db_migrations(
             &mut connection,
             MigrationContext {
@@ -424,7 +456,7 @@ mod tests {
 
         let context = AppContext {
             store: Sqlite::new(connection)?,
-            config: fake_config(),
+            config,
             git,
         };
 
@@ -529,117 +561,18 @@ mod tests {
         }
     }
 
-    fn fake_commit_templates(
-        args: Option<commit::Arguments>,
-    ) -> Vec<(&'static str, commit::Arguments)> {
-        let args = args.unwrap_or_else(fake_commit_args);
+    fn fake_template() -> (String, TemplateConfig) {
+        let config = TemplateConfig {
+            description: Faker.fake(),
+            content: "[{ticket_num}] message: '{message}', scope: '{scope}', link: '{link}'".into(),
+        };
 
-        vec![
-            (
-                "🐛",
-                commit::Arguments {
-                    template: "bug".into(),
-                    ..args.clone()
-                },
-            ),
-            (
-                "✨",
-                commit::Arguments {
-                    template: "feature".into(),
-                    ..args.clone()
-                },
-            ),
-            (
-                "🧹",
-                commit::Arguments {
-                    template: "refactor".into(),
-                    ..args.clone()
-                },
-            ),
-            (
-                "⚠️",
-                commit::Arguments {
-                    template: "break".into(),
-                    ..args.clone()
-                },
-            ),
-            (
-                "📦",
-                commit::Arguments {
-                    template: "deps".into(),
-                    ..args.clone()
-                },
-            ),
-            (
-                "📖",
-                commit::Arguments {
-                    template: "docs".into(),
-                    ..args.clone()
-                },
-            ),
-            (
-                "🧪",
-                commit::Arguments {
-                    template: "test".into(),
-                    ..args.clone()
-                },
-            ),
-        ]
+        (Faker.fake(), config)
     }
 
     fn fake_template_config() -> HashMap<String, TemplateConfig> {
-        let mut map = HashMap::new();
+        let (_, config) = fake_template();
 
-        map.insert(
-            "bug".into(),
-            TemplateConfig {
-                description: Faker.fake(),
-                content: "[{ticket_num}] 🐛 {message}".into(),
-            },
-        );
-        map.insert(
-            "feature".into(),
-            TemplateConfig {
-                description: Faker.fake(),
-                content: "[{ticket_num}] ✨ {message}".into(),
-            },
-        );
-        map.insert(
-            "refactor".into(),
-            TemplateConfig {
-                description: Faker.fake(),
-                content: "[{ticket_num}] 🧹 {message}".into(),
-            },
-        );
-        map.insert(
-            "break".into(),
-            TemplateConfig {
-                description: Faker.fake(),
-                content: "[{ticket_num}] ⚠️ {message}".into(),
-            },
-        );
-        map.insert(
-            "deps".into(),
-            TemplateConfig {
-                description: Faker.fake(),
-                content: "[{ticket_num}] 📦 {message}".into(),
-            },
-        );
-        map.insert(
-            "docs".into(),
-            TemplateConfig {
-                description: Faker.fake(),
-                content: "[{ticket_num}] 📖 {message}".into(),
-            },
-        );
-        map.insert(
-            "test".into(),
-            TemplateConfig {
-                description: Faker.fake(),
-                content: "[{ticket_num}] 🧪 {message}".into(),
-            },
-        );
-
-        map
+        HashMap::from([("bug".into(), config)])
     }
 }

--- a/src/domain/commands/actions.rs
+++ b/src/domain/commands/actions.rs
@@ -80,6 +80,7 @@ mod tests {
     use crate::app_config::TemplateConfig;
     use crate::app_context::AppContext;
     use crate::domain::adapters::CheckoutStatus;
+    use crate::migrations::DefaultConfig;
     use crate::migrations::{db_migrations, MigrationContext};
 
     use super::*;
@@ -448,8 +449,7 @@ mod tests {
         db_migrations(
             &mut connection,
             MigrationContext {
-                config_path: PathBuf::new(),
-                enable_side_effects: false,
+                default_configs: None,
                 version: None,
             },
         )?;

--- a/src/domain/models/branch.rs
+++ b/src/domain/models/branch.rs
@@ -1,13 +1,13 @@
 use chrono::{DateTime, Utc};
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Branch {
     pub name: String,
     pub ticket: String,
     pub created: DateTime<Utc>,
     pub data: Option<Vec<u8>>,
     pub link: Option<String>,
-    pub scope: Option<String>
+    pub scope: Option<String>,
 }
 
 impl Branch {
@@ -16,7 +16,7 @@ impl Branch {
         repo: &str,
         ticket: Option<String>,
         link: Option<String>,
-        scope: Option<String>
+        scope: Option<String>,
     ) -> anyhow::Result<Branch> {
         Ok(Branch {
             name: format!("{}-{}", repo.trim(), name.trim()),
@@ -47,7 +47,13 @@ mod tests {
         let link = Faker.fake::<String>();
 
         // Act
-        let branch = Branch::new(&name, &repo, Some(ticket.clone()), Some(link.clone()), Some(scope.clone()))?;
+        let branch = Branch::new(
+            &name,
+            &repo,
+            Some(ticket.clone()),
+            Some(link.clone()),
+            Some(scope.clone()),
+        )?;
 
         // Assert
         assert_eq!(branch.name, format!("{}-{}", &repo, &name));

--- a/src/domain/models/branch.rs
+++ b/src/domain/models/branch.rs
@@ -6,14 +6,24 @@ pub struct Branch {
     pub ticket: String,
     pub created: DateTime<Utc>,
     pub data: Option<Vec<u8>>,
+    pub link: Option<String>,
+    pub scope: Option<String>
 }
 
 impl Branch {
-    pub fn new(name: &str, repo: &str, ticket: Option<String>) -> anyhow::Result<Branch> {
+    pub fn new(
+        name: &str,
+        repo: &str,
+        ticket: Option<String>,
+        link: Option<String>,
+        scope: Option<String>
+    ) -> anyhow::Result<Branch> {
         Ok(Branch {
             name: format!("{}-{}", repo.trim(), name.trim()),
             created: Utc::now(),
             ticket: ticket.unwrap_or_else(|| name.into()),
+            link,
+            scope,
             data: None,
         })
     }
@@ -33,13 +43,17 @@ mod tests {
         let repo = Faker.fake::<String>();
         let name = Faker.fake::<String>();
         let ticket = Faker.fake::<String>();
+        let scope = Faker.fake::<String>();
+        let link = Faker.fake::<String>();
 
         // Act
-        let branch = Branch::new(&name, &repo, Some(ticket.clone()))?;
+        let branch = Branch::new(&name, &repo, Some(ticket.clone()), Some(link.clone()), Some(scope.clone()))?;
 
         // Assert
         assert_eq!(branch.name, format!("{}-{}", &repo, &name));
         assert_eq!(branch.ticket, ticket);
+        assert_eq!(branch.scope.unwrap(), scope);
+        assert_eq!(branch.link.unwrap(), link);
         assert!(branch.created > now);
         assert_eq!(branch.data, None);
 
@@ -54,7 +68,7 @@ mod tests {
         let repo = Faker.fake::<String>();
 
         // Act
-        let branch = Branch::new(&name, &repo, None)?;
+        let branch = Branch::new(&name, &repo, None, None, None)?;
 
         // Assert
         assert_eq!(branch.name, format!("{}-{}", &repo, &name));
@@ -74,7 +88,7 @@ mod tests {
         let repo = Faker.fake::<String>();
 
         // Act
-        let branch = Branch::new(&name, &repo, Some(ticket.clone()))?;
+        let branch = Branch::new(&name, &repo, Some(ticket.clone()), None, None)?;
 
         // Assert
         assert_eq!(branch.name, format!("{}-{}", &repo.trim(), &name.trim()));

--- a/src/migrations.rs
+++ b/src/migrations.rs
@@ -5,9 +5,14 @@ use rusqlite::Connection;
 use rusqlite_migration::{Migrations, M};
 
 #[derive(Clone)]
+pub struct DefaultConfig {
+    pub default: PathBuf,
+    pub conventional: PathBuf,
+}
+
+#[derive(Clone)]
 pub struct MigrationContext {
-    pub config_path: PathBuf,
-    pub enable_side_effects: bool,
+    pub default_configs: Option<DefaultConfig>,
     pub version: Option<usize>,
 }
 
@@ -55,10 +60,23 @@ pub fn db_migrations(
         .context("Failed to get current migration version.")?
         .into();
 
-    // Had to do this dynamically since the default path will differ between operating systems.
-    if context.enable_side_effects && version == 2 {
-        let config_default = context
-            .config_path
+    if let Some(config_paths) = context.default_configs {
+        migrate_default_configuration(config_paths, connection, version)?;
+    }
+
+    println!("git-kit migration version '{}'.", version);
+
+    Ok(migrations)
+}
+
+fn migrate_default_configuration(
+    default_configs: DefaultConfig,
+    connection: &mut Connection,
+    version: usize,
+) -> anyhow::Result<()> {
+    if version >= 2 {
+        let config_default = default_configs
+            .default
             .to_str()
             .context("Expected valid default config path.")?;
 
@@ -68,39 +86,58 @@ pub fn db_migrations(
         )?;
     }
 
-    println!("git-kit migration version '{}'.", version);
+    if version >= 3 {
+        // Update to latest changed path for the default configuration. '.git-kit.yml' -> 'templates/default.yml'
+        let default_path = default_configs
+            .default
+            .to_str()
+            .context("Expected valid default config path.")?;
+        connection.execute(
+            "UPDATE config SET path = ?1 WHERE key='default'",
+            [default_path],
+        )?;
 
-    Ok(migrations)
+        // Insert the new 'conventional' default configuration.
+        // Note there is a possibility for conflicts with user custom configs and the name 'conventional' which be replaced.
+        // User custom configs using the name 'conventional' will have to re-added under a new name via the 'config add' command.
+        let conventional_path = default_configs
+            .conventional
+            .to_str()
+            .context("Expected valid conventional config path.")?;
+        connection.execute(
+            "REPLACE INTO config (key, path, status) VALUES ('conventional', ?1, 'DISABLED');",
+            [conventional_path],
+        )?;
+    }
+
+    Ok(())
 }
 
 #[cfg(test)]
 mod tests {
     use rusqlite::Connection;
-    use std::path::Path;
+    use std::path::{Path, PathBuf};
 
-    use crate::migrations::{db_migrations, MigrationContext};
+    use crate::migrations::{db_migrations, DefaultConfig, MigrationContext};
 
-    fn arrange(version: usize) -> (Connection, Vec<String>, MigrationContext) {
+    fn arrange(context: MigrationContext) -> (Connection, Vec<String>, MigrationContext) {
         let mut connection = Connection::open_in_memory().unwrap();
 
-        let defaults = MigrationContext {
-            config_path: Path::new(".").to_owned(),
-            enable_side_effects: true,
-            version: Some(version),
-        };
-
-        let migrations = db_migrations(&mut connection, defaults.clone()).unwrap();
+        let migrations = db_migrations(&mut connection, context.clone()).unwrap();
         // Validate migrations where applied.
         assert!(migrations.validate().is_ok());
 
         let tables = get_table_names(&mut connection);
 
-        (connection, tables, defaults)
+        (connection, tables, context)
     }
 
     #[test]
     fn verify_migration_1() {
-        let (_, tables, _) = arrange(1);
+        let (_, tables, _) = arrange(MigrationContext {
+            default_configs: None,
+            version: Some(1),
+        });
 
         assert_eq!(tables.len(), 1);
         assert!(tables.contains(&"branch".to_string()));
@@ -108,27 +145,98 @@ mod tests {
 
     #[test]
     fn verify_migration_2() {
-        let (connection, tables, _) = arrange(2);
+        let context = MigrationContext {
+            default_configs: Some(DefaultConfig {
+                default: Path::new("default.yml").to_owned(),
+                conventional: PathBuf::new(),
+            }),
+            version: Some(2),
+        };
+        let (connection, tables, _) = arrange(context);
 
         assert_eq!(tables.len(), 2);
         assert!(tables.contains(&"branch".to_string()));
         assert!(tables.contains(&"config".to_string()));
 
-        let mut default_config = connection
-            .prepare("SELECT * FROM config WHERE key='default'")
-            .unwrap();
+        let default_configs = get_default_configs(&connection);
 
-        let config = default_config
-            .query_map([], |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)))
-            .unwrap()
-            .collect::<Result<Vec<(String, String, String)>, _>>()
-            .unwrap();
+        assert_eq!(default_configs.len(), 1);
+        let (name, path, status) = default_configs.get(0).unwrap();
 
-        assert_eq!(config.len(), 1);
-        let (name, path, status) = &config[0];
         assert_eq!(name, "default");
-        assert_eq!(path, ".");
-        assert_eq!(status, "ACTIVE")
+        assert_eq!(path, "default.yml");
+        assert_eq!(status, "ACTIVE");
+    }
+
+    #[test]
+    fn verify_migration_3_and_4() {
+        let context = MigrationContext {
+            default_configs: Some(DefaultConfig {
+                default: Path::new("default.yml").to_owned(),
+                conventional: Path::new("conventional.yml").to_owned(),
+            }),
+            version: Some(4),
+        };
+        let (connection, tables, _) = arrange(context);
+
+        assert_eq!(tables.len(), 2);
+        assert!(tables.contains(&"branch".to_string()));
+        assert!(tables.contains(&"config".to_string()));
+
+        let default_configs = get_default_configs(&connection);
+
+        assert_eq!(default_configs.len(), 2);
+        let default_config = default_configs.get(1).unwrap();
+        let conventional_config = default_configs.get(0).unwrap();
+
+        assert_eq!(default_config.0, "default");
+        assert_eq!(default_config.1, "default.yml");
+        assert_eq!(default_config.2, "ACTIVE");
+
+        assert_eq!(conventional_config.0, "conventional");
+        assert_eq!(conventional_config.1, "conventional.yml");
+        assert_eq!(conventional_config.2, "INACTIVE");
+    }
+
+    #[test]
+    fn verify_any_custom_user_conventional_is_replaced_via_the_new_default_at_migration_3_and_4() {
+        // Arrange
+        // Apply a previous version first.
+        let context = MigrationContext {
+            default_configs: None,
+            version: Some(2),
+        };
+        let (connection, ..) = arrange(context);
+
+        // Insert custom user 'conventional' config and assure dummy data is there.
+        connection.execute("INSERT INTO config (key, path, status) VALUES ('conventional', 'custom_path.yml', 'ACTIVE');", []).unwrap();
+        let default_configs = get_default_configs(&connection);
+        let conventional_config = default_configs.get(0).unwrap();
+
+        assert_eq!(conventional_config.0, "conventional");
+        assert_eq!(conventional_config.1, "custom_path.yml");
+        assert_eq!(conventional_config.2, "ACTIVE");
+
+        connection.close().unwrap();
+
+        // Act
+        let context = MigrationContext {
+            default_configs: Some(DefaultConfig {
+                default: Path::new("default.yml").to_owned(),
+                conventional: Path::new("conventional.yml").to_owned(),
+            }),
+            version: Some(4),
+        };
+
+        let (connection, ..) = arrange(context);
+
+        // Assert
+        let default_configs = get_default_configs(&connection);
+        let conventional_config = default_configs.get(0).unwrap();
+
+        assert_eq!(conventional_config.0, "conventional");
+        assert_eq!(conventional_config.1, "conventional.yml");
+        assert_eq!(conventional_config.2, "INACTIVE");
     }
 
     fn get_table_names(connection: &mut Connection) -> Vec<String> {
@@ -146,5 +254,17 @@ mod tests {
             .unwrap();
 
         tables
+    }
+
+    fn get_default_configs(connection: &Connection) -> Vec<(String, String, String)> {
+        let mut default_configs = connection
+            .prepare("SELECT * FROM config WHERE key='default' OR key='conventional'")
+            .unwrap();
+
+        default_configs
+            .query_map([], |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)))
+            .unwrap()
+            .collect::<Result<Vec<(String, String, String)>, _>>()
+            .unwrap()
     }
 }

--- a/src/migrations.rs
+++ b/src/migrations.rs
@@ -195,7 +195,7 @@ mod tests {
 
         assert_eq!(conventional_config.0, "conventional");
         assert_eq!(conventional_config.1, "conventional.yml");
-        assert_eq!(conventional_config.2, "INACTIVE");
+        assert_eq!(conventional_config.2, "DISABLED");
     }
 
     #[test]
@@ -236,7 +236,7 @@ mod tests {
 
         assert_eq!(conventional_config.0, "conventional");
         assert_eq!(conventional_config.1, "conventional.yml");
-        assert_eq!(conventional_config.2, "INACTIVE");
+        assert_eq!(conventional_config.2, "DISABLED");
     }
 
     fn get_table_names(connection: &mut Connection) -> Vec<String> {

--- a/src/migrations.rs
+++ b/src/migrations.rs
@@ -37,7 +37,7 @@ pub fn db_migrations(
         M::up("ALTER TABLE branch ADD COLUMN link TEXT;")
             .down("ALTER TABLE branch DROP COLUMN link;"),
         M::up("ALTER TABLE branch ADD COLUMN scope TEXT;")
-            .down("ALTER TABLE branch DROP COLUMN scope;")
+            .down("ALTER TABLE branch DROP COLUMN scope;"),
     ]);
 
     if let Some(version) = context.version {

--- a/src/migrations.rs
+++ b/src/migrations.rs
@@ -34,6 +34,10 @@ pub fn db_migrations(
             );",
         )
         .down("DROP TABLE config;"),
+        M::up("ALTER TABLE branch ADD COLUMN link TEXT;")
+            .down("ALTER TABLE branch DROP COLUMN link;"),
+        M::up("ALTER TABLE branch ADD COLUMN scope TEXT;")
+            .down("ALTER TABLE branch DROP COLUMN scope;")
     ]);
 
     if let Some(version) = context.version {

--- a/src/utils/merge.rs
+++ b/src/utils/merge.rs
@@ -1,0 +1,8 @@
+pub fn merge<T>(preferred: Option<T>, default: Option<T>) -> Option<T> {
+    match (preferred, default) {
+        (None, None) => None,
+        (None, Some(def)) => Some(def),
+        (Some(pref), None) => Some(pref),
+        (Some(pref), Some(_)) => Some(pref),
+    }
+}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,6 +1,8 @@
 pub mod file;
+mod merge;
 pub mod string;
 mod try_convert;
 
 pub use file::get_file_contents;
+pub use merge::merge;
 pub use try_convert::TryConvert;

--- a/src/utils/string.rs
+++ b/src/utils/string.rs
@@ -1,7 +1,7 @@
 pub fn into_option<S: Into<String>>(value: S) -> Option<String> {
-    let value: String = value.into();
+    let value: String = value.into().trim().to_string();
 
-    if !value.trim().is_empty() {
+    if !value.is_empty() {
         Some(value)
     } else {
         None
@@ -9,24 +9,13 @@ pub fn into_option<S: Into<String>>(value: S) -> Option<String> {
 }
 
 pub trait OptionStr<T> {
-    fn map_empty_to_none(self) -> Option<T>;
-
-    fn map_non_empty(self, map: fn(T) -> T) -> Option<T>;
+    fn none_if_empty(self) -> Option<T>;
 }
 
 impl OptionStr<String> for Option<String> {
-    fn map_empty_to_none(self) -> Option<String> {
+    fn none_if_empty(self) -> Option<String> {
         match self {
-            Some(value) if value.trim().is_empty() => None,
-            Some(value) => Some(value.trim().to_string()),
-            None => None,
-        }
-    }
-
-    fn map_non_empty(self, map: fn(String) -> String) -> Option<String> {
-        match self {
-            Some(value) if value.trim().is_empty() => None,
-            Some(value) => Some(map(value.trim().to_string())),
+            Some(value) => into_option(value),
             None => None,
         }
     }
@@ -40,7 +29,7 @@ mod tests {
     fn empty_strings_wrapped_in_some_should_be_mapped_to_none() {
         for item in ["", " ", "\t", "\n"] {
             let option = Some(item.into());
-            let option = option.map_empty_to_none();
+            let option = option.none_if_empty();
 
             assert!(option.is_none());
         }
@@ -50,7 +39,7 @@ mod tests {
     fn non_empty_strings_wrapped_in_some_should_not_be_remapped_to_none() {
         for item in [" h ", "hello"] {
             let option = Some(item.into());
-            let option = option.map_empty_to_none();
+            let option = option.none_if_empty();
 
             assert!(option.is_some());
             assert_eq!(item.trim(), option.unwrap());

--- a/templates/conventional.yml
+++ b/templates/conventional.yml
@@ -1,0 +1,93 @@
+version: 1
+commit:
+  name: conventional
+  templates:
+    fix:
+      description: Fix that resolves an unintended issue i.e bug
+      content: |
+        fix({scope}): {message}
+
+
+
+        Issue: {ticket_num} {link}
+  
+    feat:
+      description: Adds new functionality to the code base
+      content: |
+        feat({scope}): {message}
+
+
+
+        Issue: {ticket_num} {link}
+    
+    test:
+      description: Adds or improves the existing tests related to the code base
+      content: |
+        test({scope}): {message}
+
+
+
+        Issue: {ticket_num} {link}
+
+    refactor:
+      description: Improvement of code / structure without adding new functionality
+      content: |
+        refactor({scope}): {message}
+
+
+
+        Issue: {ticket_num} {link}
+
+    style:
+      description: Formatting, lint fixes i.e missing semi colons, etc; 
+      content: |
+        style({scope}): {message}
+
+
+
+        Issue: {ticket_num} {link}
+
+    chore:
+      description: Grunt work such as updating or migrating dependencies. 
+      content: |
+        chore({scope}): {message}
+
+
+
+        Issue: {ticket_num} {link}
+
+    docs:
+      description: Adds or improves documentation, i.e README's, code comments, etc.
+      content: |
+        docs({scope}): {message}
+
+
+
+        Issue: {ticket_num} {link}
+
+    perf:
+      description: Improvement of code's performance i.e speed, memory, etc 
+      content: |
+        pref({scope}): {message}
+
+
+
+        Issue: {ticket_num} {link}
+
+    build:
+      description: Changes that affect the build system or external dependencies i.e npm
+      content: |
+        build({scope}): {message}
+
+
+
+        Issue: {ticket_num} {link}
+    
+    ci:
+      description: Changes to CI configuration files and scripts
+      content: |
+        ci({scope}): {message}
+
+
+
+        Issue: {ticket_num} {link}

--- a/templates/default.yml
+++ b/templates/default.yml
@@ -1,9 +1,12 @@
+version: 1
 commit:
+  name: default
   templates:
     bug:
       description: Fix that resolves an unintended issue
       content: |
         [{ticket_num}] 🐛 {message}
+
     break:
       description: Breaking change that could break a consuming application
       content: |
@@ -19,7 +22,7 @@ commit:
       content: |
         [{ticket_num}] 📖 {message}
 
-    feature:
+    feat:
       description: Adds new functionality
       content: |
         [{ticket_num}] ✨ {message}
@@ -33,3 +36,13 @@ commit:
       description: Adds or improves the existing tests related to the code base
       content: |
         [{ticket_num}] 🧪 {message}
+
+    chore:
+      description: Adds or improves the existing tests related to the code base
+      content: |
+        [{ticket_num}] 📋 {message}
+
+    ci:
+      description: Changes to CI configuration files and scripts
+      content: |
+        [{ticket_num}] 🚰 {message}

--- a/templates/default.yml
+++ b/templates/default.yml
@@ -38,7 +38,7 @@ commit:
         [{ticket_num}] 🧪 {message}
 
     chore:
-      description: Adds or improves the existing tests related to the code base
+      description: Regular code maintenance.
       content: |
         [{ticket_num}] 📋 {message}
 


### PR DESCRIPTION
## Description 

- `link` & `scope` params to `checkout` & `context` commands.
- Extend existing default template with additional commit templates for `ci` and `chore`.
- Introduce a new default template called `conventional` that follows the [conventional commits standard](https://www.conventionalcommits.org/en/v1.0.0/).

Commit summary:
- 📋 Add migrations for `scope` & `link` for the `branch` table
- ✨ Update branch model with 'scope' & 'link'
- ✨ Update cli args to include `scope` & `link`
- 🧹 Clean up utils.
- ✨ Add commit logic for `link` & `scope`
- 🧹 Move default template & add conventional template.
- 🐛 Fix error message on invalid config status.
- 🧪 Update tests.
- ✨ Add 'conventional' config to migrations to make use of `scope` & `link` params.

⚠️  BREAKING CHANGE:
- Any existing users with a custom config called `conventional` will be overridden, users will just have to re-link their config with a new name via the `config add` command.
- Rename default commit template `feature`  -> `feat`

<!--- Describe your changes in detail to help reviewer and others -->

## Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] ⚠️ Breaking change
- [x] ✨ Feature (non-breaking change which adds functionality)
- [x] 🐛 Bug (non-breaking change which fixes an issue)

## 🧪 Testing

- [x] Unit tests added
- [x] Integration tests added

<!--- Any other comments for testing -->

## ✍️ The Oath

<!--- I do solemnly swear that...: -->

- [x] I have used formatting & linting tools to clean up code?
- [x] Changes include tests to cover my changes?
- [x] Changes include have sufficient logging, where necessary?
