### PR TITLE
🐛 Fix commit not aborting when no changes.

### DIFF
--- a/src/adapters/git.rs
+++ b/src/adapters/git.rs
@@ -22,7 +22,7 @@ impl Git {
 }
 
 impl adapters::Git for Git {
-    fn get_repo_name(&self) -> anyhow::Result<String> {
+    fn repository_name(&self) -> anyhow::Result<String> {
         let repo_dir = self.root_directory()?.try_convert()?;
 
         let repo = repo_dir
@@ -35,7 +35,7 @@ impl adapters::Git for Git {
         Ok(repo.trim().into())
     }
 
-    fn get_branch_name(&self) -> anyhow::Result<String> {
+    fn branch_name(&self) -> anyhow::Result<String> {
         let branch: String = Git::command(&["branch", "--show-current"]).try_convert()?;
         log::info!("current git branch name '{}'", branch);
 
@@ -111,7 +111,7 @@ mod tests {
         let git = Git;
 
         // TODO: Find a more testable approach to check stdout maybe?
-        assert_eq!(git.get_repo_name()?, "git-kit");
+        assert_eq!(git.repository_name()?, "git-kit");
 
         Ok(())
     }

--- a/src/adapters/git.rs
+++ b/src/adapters/git.rs
@@ -1,4 +1,4 @@
-use anyhow::Context;
+use anyhow::{Context, Ok};
 use std::{
     path::{Path, PathBuf},
     process::Command,
@@ -67,6 +67,26 @@ impl adapters::Git for Git {
         log::info!("git root directory {}", dir);
 
         Ok(Path::new(dir.trim()).to_owned())
+    }
+
+    fn template_file_path(&self) -> anyhow::Result<PathBuf> {
+        // Create a template file and store in the .git directory
+        let path = self
+            .root_directory()?
+            .join(".git")
+            .join("GIT_KIT_COMMIT_TEMPLATE");
+
+        Ok(path)
+    }
+
+    fn commit_with_template(&self, template: &Path) -> anyhow::Result<()> {
+        let template = template
+            .as_os_str()
+            .to_str()
+            .context("Failed to convert path to str.")?;
+        Git::command(&["commit", "--template", template]).status()?;
+
+        Ok(())
     }
 }
 

--- a/src/adapters/git.rs
+++ b/src/adapters/git.rs
@@ -1,4 +1,4 @@
-use anyhow::{Context, Ok};
+use anyhow::Context;
 use std::{
     path::{Path, PathBuf},
     process::Command,
@@ -55,13 +55,6 @@ impl adapters::Git for Git {
         Ok(())
     }
 
-    fn commit(&self, msg: &str) -> anyhow::Result<()> {
-        log::info!("git commit with message '{}'", msg);
-        Git::command(&["commit", "-m", msg, "-e"]).status()?;
-
-        Ok(())
-    }
-
     fn root_directory(&self) -> anyhow::Result<PathBuf> {
         let dir = Git::command(&["rev-parse", "--show-toplevel"]).try_convert()?;
         log::info!("git root directory {}", dir);
@@ -70,7 +63,8 @@ impl adapters::Git for Git {
     }
 
     fn template_file_path(&self) -> anyhow::Result<PathBuf> {
-        // Create a template file and store in the .git directory
+        // Template file and stored in the .git directory to avoid users having to adding to their .gitignore
+        // In future maybe we could make our own .git-kit dir to house config / templates along with this.
         let path = self
             .root_directory()?
             .join(".git")

--- a/src/adapters/git.rs
+++ b/src/adapters/git.rs
@@ -78,6 +78,8 @@ impl adapters::Git for Git {
         template: &Path,
         completed: CommitMsgStatus,
     ) -> anyhow::Result<()> {
+        log::info!("commit template with CommitMsgStatus: '{:?}'", completed);
+
         let template = template
             .as_os_str()
             .to_str()
@@ -88,6 +90,7 @@ impl adapters::Git for Git {
         // Pre-cautionary measure encase 'message' is provided but still matches template exactly.
         // Otherwise git will just abort the commit if theres no difference / change from the template.
         if completed == CommitMsgStatus::Completed {
+            log::info!("allowing an empty message on commit");
             args.push("--allow-empty-message");
         }
 

--- a/src/cli/commit/args.rs
+++ b/src/cli/commit/args.rs
@@ -102,7 +102,10 @@ mod tests {
     use crate::{
         adapters::sqlite::Sqlite,
         app_config::{AppConfig, CommitConfig, TemplateConfig},
-        domain::{adapters::CheckoutStatus, models::Branch},
+        domain::{
+            adapters::{CheckoutStatus, CommitMsgStatus},
+            models::Branch,
+        },
         migrations::{db_migrations, MigrationContext},
     };
     use fake::{Fake, Faker};
@@ -146,7 +149,11 @@ mod tests {
             panic!("Did not expect Git 'template_file_path' to be called");
         }
 
-        fn commit_with_template(&self, _: &std::path::Path) -> anyhow::Result<()> {
+        fn commit_with_template(
+            &self,
+            _: &std::path::Path,
+            _: CommitMsgStatus,
+        ) -> anyhow::Result<()> {
             panic!("Did not expect Git 'commit_with_template' to be called");
         }
     }

--- a/src/cli/commit/args.rs
+++ b/src/cli/commit/args.rs
@@ -72,10 +72,7 @@ impl Arguments {
         log::info!("generate commit message for '{}'", &template);
         let branch = context
             .store
-            .get_branch(
-                &context.git.get_branch_name()?,
-                &context.git.get_repo_name()?,
-            )
+            .get_branch(&context.git.branch_name()?, &context.git.repository_name()?)
             .ok();
 
         let (ticket, scope, link) = branch
@@ -129,11 +126,11 @@ mod tests {
     }
 
     impl Git for TestCommand {
-        fn get_repo_name(&self) -> anyhow::Result<String> {
+        fn repository_name(&self) -> anyhow::Result<String> {
             Ok(self.repo.to_owned())
         }
 
-        fn get_branch_name(&self) -> anyhow::Result<String> {
+        fn branch_name(&self) -> anyhow::Result<String> {
             Ok(self.branch_name.to_owned())
         }
 

--- a/src/cli/commit/args.rs
+++ b/src/cli/commit/args.rs
@@ -135,15 +135,19 @@ mod tests {
         }
 
         fn checkout(&self, _name: &str, _status: CheckoutStatus) -> anyhow::Result<()> {
-            todo!()
-        }
-
-        fn commit(&self, _msg: &str) -> anyhow::Result<()> {
-            todo!()
+            panic!("Did not expect Git 'checkout' to be called");
         }
 
         fn root_directory(&self) -> anyhow::Result<PathBuf> {
-            todo!()
+            panic!("Did not expect Git 'root_directory' to be called");
+        }
+
+        fn template_file_path(&self) -> anyhow::Result<PathBuf> {
+            panic!("Did not expect Git 'template_file_path' to be called");
+        }
+
+        fn commit_with_template(&self, _: &std::path::Path) -> anyhow::Result<()> {
+            panic!("Did not expect Git 'commit_with_template' to be called");
         }
     }
 

--- a/src/domain/adapters/git.rs
+++ b/src/domain/adapters/git.rs
@@ -18,10 +18,10 @@ pub trait Git {
     fn root_directory(&self) -> anyhow::Result<PathBuf>;
 
     /// Get the current git repository name.
-    fn get_repo_name(&self) -> anyhow::Result<String>;
+    fn repository_name(&self) -> anyhow::Result<String>;
 
     /// Get the current checked out branch name.
-    fn get_branch_name(&self) -> anyhow::Result<String>;
+    fn branch_name(&self) -> anyhow::Result<String>;
 
     /// Checkout an existing branch of create a new branch if not.
     fn checkout(&self, name: &str, status: CheckoutStatus) -> anyhow::Result<()>;

--- a/src/domain/adapters/git.rs
+++ b/src/domain/adapters/git.rs
@@ -20,9 +20,6 @@ pub trait Git {
     /// Checkout an existing branch of create a new branch if not.
     fn checkout(&self, name: &str, status: CheckoutStatus) -> anyhow::Result<()>;
 
-    /// Commit changes and open editor with the template.
-    fn commit(&self, msg: &str) -> anyhow::Result<()>;
-
     /// Get the commit file path for the current repository.
     fn template_file_path(&self) -> anyhow::Result<PathBuf>;
 

--- a/src/domain/adapters/git.rs
+++ b/src/domain/adapters/git.rs
@@ -6,6 +6,12 @@ pub enum CheckoutStatus {
     Existing,
 }
 
+#[derive(Debug, PartialEq, Eq)]
+pub enum CommitMsgStatus {
+    InComplete,
+    Completed,
+}
+
 /// Used to abstract cli git commands for testing.
 pub trait Git {
     /// Get the root directory of the current git repo.
@@ -24,5 +30,9 @@ pub trait Git {
     fn template_file_path(&self) -> anyhow::Result<PathBuf>;
 
     /// Commit changes and open and editor with template file.
-    fn commit_with_template(&self, template: &Path) -> anyhow::Result<()>;
+    fn commit_with_template(
+        &self,
+        template: &Path,
+        completed: CommitMsgStatus,
+    ) -> anyhow::Result<()>;
 }

--- a/src/domain/adapters/git.rs
+++ b/src/domain/adapters/git.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 #[derive(Debug, PartialEq, Eq)]
 pub enum CheckoutStatus {
@@ -22,4 +22,10 @@ pub trait Git {
 
     /// Commit changes and open editor with the template.
     fn commit(&self, msg: &str) -> anyhow::Result<()>;
+
+    /// Get the commit file path for the current repository.
+    fn template_file_path(&self) -> anyhow::Result<PathBuf>;
+
+    /// Commit changes and open and editor with template file.
+    fn commit_with_template(&self, template: &Path) -> anyhow::Result<()>;
 }

--- a/src/domain/adapters/mod.rs
+++ b/src/domain/adapters/mod.rs
@@ -1,5 +1,5 @@
 mod git;
 mod store;
 
-pub use git::{CheckoutStatus, Git};
+pub use git::{CheckoutStatus, CommitMsgStatus, Git};
 pub use store::Store;

--- a/src/domain/commands/actions.rs
+++ b/src/domain/commands/actions.rs
@@ -24,8 +24,8 @@ impl<'a, C: Git, S: Store> Actor for Actions<'a, C, S> {
     fn current(&self, args: context::Arguments) -> anyhow::Result<Branch> {
         // We want to store the branch name against and ticket number
         // So whenever we commit we get the ticket number from the branch
-        let repo_name = self.context.git.get_repo_name()?;
-        let branch_name = self.context.git.get_branch_name()?;
+        let repo_name = self.context.git.repository_name()?;
+        let branch_name = self.context.git.branch_name()?;
 
         let branch = Branch::new(&branch_name, &repo_name, args.ticket, args.link, args.scope)?;
         self.context.store.persist_branch(&branch)?;
@@ -48,7 +48,7 @@ impl<'a, C: Git, S: Store> Actor for Actions<'a, C, S> {
 
         // We want to store the branch name against and ticket number
         // So whenever we commit we get the ticket number from the branch
-        let repo_name = self.context.git.get_repo_name()?;
+        let repo_name = self.context.git.repository_name()?;
         let branch = Branch::new(&args.name, &repo_name, args.ticket, args.link, args.scope)?;
         self.context.store.persist_branch(&branch)?;
 
@@ -431,8 +431,8 @@ mod tests {
         let context = fake_context(GitCommandMock::fake(), config)?;
         let actions = Actions::new(&context);
 
-        let branch_name = Some(context.git.get_branch_name()?);
-        let repo_name = Some(context.git.get_repo_name()?);
+        let branch_name = Some(context.git.branch_name()?);
+        let repo_name = Some(context.git.repository_name()?);
         let ticket = None;
         let branch = Branch {
             link: Some(Faker.fake()),
@@ -527,14 +527,14 @@ mod tests {
     }
 
     impl Git for GitCommandMock {
-        fn get_repo_name(&self) -> anyhow::Result<String> {
+        fn repository_name(&self) -> anyhow::Result<String> {
             self.repo
                 .as_ref()
                 .map(|s| s.to_owned())
                 .map_err(|e| anyhow!(e.to_owned()))
         }
 
-        fn get_branch_name(&self) -> anyhow::Result<String> {
+        fn branch_name(&self) -> anyhow::Result<String> {
             self.branch_name
                 .as_ref()
                 .map(|s| s.to_owned())

--- a/src/domain/commands/actions.rs
+++ b/src/domain/commands/actions.rs
@@ -59,7 +59,10 @@ impl<'a, C: Git, S: Store> Actor for Actions<'a, C, S> {
 
         let contents = args.commit_message(config.content.clone(), self.context)?;
 
-        self.context.git.commit(&contents)?;
+        let template_file = self.context.git.template_file_path()?;
+        std::fs::write(&template_file, &contents)?;
+
+        self.context.git.commit_with_template(&template_file)?;
 
         Ok(contents)
     }


### PR DESCRIPTION
## Description 
Fix up commit to abort when no changes are made in the message.

This is done via relying on git's validation we now provide the generated commit contents as a temaple file.
```bash
# Before, Makes the commit and then allows you to edit the message like `--amend`
git commit -m $TEMPLATE -e

# After, Confirm / Alter the message add then commit.
git commit --template $TEMPLATE
```

- 🐛 Fix up commit to use a template.
- 🧹 Remove old 'commit' logic.
- 🧪 Update the tests to use a temp file path for templates.
- 🧹  Rename 'Git' methods remove 'get_' prefix.


## Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] 🐛 Bug (non-breaking change which fixes an issue)

## 🧪 Testing

- [x] Tested in Development Environment

<!--- Any other comments for testing -->

## ✍️ The Oath

<!--- I do solemnly swear that...: -->

- [x] I have used formatting & linting tools to clean up code?
- [x] Changes include tests to cover my changes?
- [x] Changes include have sufficient logging, where necessary?
